### PR TITLE
Implement GitHub API utilities and CI token workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+on:
+  push:
+    branches: [main]
+  pull_request:
+jobs:
+  set-token:
+    uses: ./.github/workflows/set-token.yml
+    secrets: inherit
+  test:
+    needs: set-token
+    runs-on: ubuntu-latest
+    env:
+      GH_BOT_TOKEN: ${{ needs.set-token.outputs.token }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - run: pip install -r requirements.txt
+      - run: pytest -q

--- a/.github/workflows/daily-run.yml
+++ b/.github/workflows/daily-run.yml
@@ -1,0 +1,22 @@
+name: Daily Run
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 8 * * *'
+jobs:
+  set-token:
+    uses: ./.github/workflows/set-token.yml
+    secrets: inherit
+  run:
+    needs: set-token
+    runs-on: ubuntu-latest
+    env:
+      GH_BOT_TOKEN: ${{ needs.set-token.outputs.token }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - run: pip install -r requirements.txt
+      - run: python mae_watcher.py --owner bmparent --repo little-eidos-playground
+      - run: python emergent_intelligence.py

--- a/.github/workflows/prune.yml
+++ b/.github/workflows/prune.yml
@@ -1,0 +1,24 @@
+name: Prune Branches
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * 0'
+jobs:
+  set-token:
+    uses: ./.github/workflows/set-token.yml
+    secrets: inherit
+  prune:
+    needs: set-token
+    runs-on: ubuntu-latest
+    env:
+      GH_BOT_TOKEN: ${{ needs.set-token.outputs.token }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - run: pip install -r requirements.txt
+      - run: |
+          python -m agents.branch_pruner \
+            --owner bmparent --repo little-eidos-playground \
+            --days 30 --keep 5 --prefix autogen/

--- a/.github/workflows/set-token.yml
+++ b/.github/workflows/set-token.yml
@@ -1,0 +1,16 @@
+name: set-token
+on:
+  workflow_call:
+    secrets:
+      GH_BOT_TOKEN:
+        required: true
+jobs:
+  export:
+    runs-on: ubuntu-latest
+    outputs:
+      token: ${{ steps.out.outputs.token }}
+    steps:
+      - id: out
+        env:
+          GH_BOT_TOKEN: ${{ secrets.GH_BOT_TOKEN }}
+        run: echo "token=$GH_BOT_TOKEN" >> "$GITHUB_OUTPUT"

--- a/README.md
+++ b/README.md
@@ -27,3 +27,13 @@ streamlit run ui/app.py
 ```
 
 ![UI preview](docs/ui_preview.png)
+
+## \ud83d\udd10 GitHub Token Setup
+
+Several helper agents interact with the GitHub API. Create a Personal Access
+Token with scopes `repo:status`, `delete_repo`, and `public_repo` and add it to
+this repository as the secret `GH_BOT_TOKEN`. Locally, export the same token in
+`GH_BOT_TOKEN` so utilities such as `agents.branch_pruner` can authenticate.
+
+The agents now rely on `gh_api.py` rather than invoking `git` directly for
+branch enumeration and deletion.

--- a/agents/branch_pruner.py
+++ b/agents/branch_pruner.py
@@ -1,0 +1,46 @@
+import argparse
+import datetime as dt
+from typing import List, Tuple
+
+import gh_api
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Prune old Git branches via API")
+    parser.add_argument("--owner", required=True)
+    parser.add_argument("--repo", required=True)
+    parser.add_argument("--days", type=int, default=30)
+    parser.add_argument("--keep", type=int, default=5)
+    parser.add_argument("--prefix", default="")
+    return parser.parse_args()
+
+
+def fetch_branch_date(owner: str, repo: str, branch: str) -> dt.datetime:
+    commit = gh_api.api_request(
+        "GET", f"/repos/{owner}/{repo}/commits/{branch}"
+    )
+    ts = commit["commit"]["committer"]["date"]
+    return dt.datetime.fromisoformat(ts.replace("Z", "+00:00"))
+
+
+def main() -> None:
+    args = parse_args()
+    branches = gh_api.list_branches(args.owner, args.repo, prefix=args.prefix or None)
+
+    info: List[Tuple[str, dt.datetime]] = []
+    for b in branches:
+        info.append((b["name"], fetch_branch_date(args.owner, args.repo, b["name"])))
+
+    info.sort(key=lambda x: x[1], reverse=True)
+    keep_set = {name for name, _ in info[: args.keep]}
+    cutoff = dt.datetime.utcnow() - dt.timedelta(days=args.days)
+
+    for name, date in info:
+        if name in keep_set or date > cutoff:
+            continue
+        print(f"Deleting {name} last updated {date.isoformat()}")
+        gh_api.delete_branch(args.owner, args.repo, name)
+
+
+if __name__ == "__main__":
+    main()

--- a/gh_api.py
+++ b/gh_api.py
@@ -1,0 +1,93 @@
+import os
+import time
+from typing import Any, Dict, List, Optional
+
+import requests
+
+BASE_URL = "https://api.github.com"
+
+
+def _get_token() -> str:
+    token = os.getenv("GH_BOT_TOKEN")
+    if not token:
+        raise RuntimeError("GH_BOT_TOKEN environment variable not set")
+    return token
+
+
+def _raw_request(method: str, path: str, **kwargs: Any) -> requests.Response:
+    url = BASE_URL + path
+    headers = kwargs.pop("headers", {})
+    headers.setdefault("Authorization", f"Bearer {_get_token()}")
+    headers.setdefault("Accept", "application/vnd.github+json")
+
+    while True:
+        resp = requests.request(method, url, headers=headers, **kwargs)
+        if resp.status_code == 403 and resp.headers.get("X-RateLimit-Remaining") == "0":
+            reset = int(resp.headers.get("X-RateLimit-Reset", "0"))
+            time.sleep(max(reset - int(time.time()), 1))
+            continue
+        if resp.status_code >= 400:
+            raise RuntimeError(f"GitHub API error {resp.status_code}: {resp.text}")
+        if resp.headers.get("X-RateLimit-Remaining") == "0":
+            reset = int(resp.headers.get("X-RateLimit-Reset", "0"))
+            time.sleep(max(reset - int(time.time()), 1))
+        return resp
+
+
+def api_request(method: str, path: str, **kwargs: Any) -> Dict:
+    """Generic GitHub API request returning parsed JSON."""
+    resp = _raw_request(method, path, **kwargs)
+    if resp.status_code == 204:
+        return {}
+    return resp.json()
+
+
+def get_repo(owner: str, repo: str) -> Dict:
+    return api_request("GET", f"/repos/{owner}/{repo}")
+
+
+def list_branches(owner: str, repo: str, prefix: Optional[str] = None) -> List[Dict]:
+    branches: List[Dict] = []
+    path = f"/repos/{owner}/{repo}/branches"
+    params = {"per_page": 100}
+    while True:
+        resp = _raw_request("GET", path, params=params)
+        data = resp.json()
+        for b in data:
+            if prefix is None or b["name"].startswith(prefix):
+                branches.append(b)
+        if "next" not in resp.links:
+            break
+        next_url = resp.links["next"]["url"]
+        path = next_url.replace(BASE_URL, "")
+        params = {}
+    return branches
+
+
+def delete_branch(owner: str, repo: str, branch: str) -> None:
+    api_request("DELETE", f"/repos/{owner}/{repo}/git/refs/heads/{branch}")
+
+
+def search_code(
+    query: str,
+    owner: Optional[str] = None,
+    repo: Optional[str] = None,
+    per_page: int = 30,
+) -> List[Dict]:
+    q = query
+    if owner and repo:
+        q += f" repo:{owner}/{repo}"
+    page = 1
+    items: List[Dict] = []
+    while True:
+        data = api_request(
+            "GET",
+            "/search/code",
+            params={"q": q, "per_page": per_page, "page": page},
+        )
+        batch = data.get("items", [])
+        items.extend(batch)
+        if len(batch) < per_page:
+            break
+        page += 1
+    return items

--- a/mae_watcher.py
+++ b/mae_watcher.py
@@ -1,0 +1,33 @@
+import argparse
+import subprocess
+import sys
+
+import gh_api
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Check local repo against GitHub")
+    parser.add_argument("--owner", required=True)
+    parser.add_argument("--repo", required=True)
+    parser.add_argument("--branch", default=None)
+    args = parser.parse_args()
+
+    repo = gh_api.get_repo(args.owner, args.repo)
+    branch = args.branch or repo["default_branch"]
+    remote = gh_api.api_request(
+        "GET", f"/repos/{args.owner}/{args.repo}/commits/{branch}"
+    )
+    remote_sha = remote["sha"]
+
+    local_sha = (
+        subprocess.check_output(["git", "rev-parse", branch]).decode().strip()
+    )
+
+    if local_sha != remote_sha:
+        print(f"Local {branch} is {local_sha}, remote is {remote_sha}")
+        sys.exit(1)
+    print("Repository is up to date")
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -121,3 +121,4 @@ webencodings==0.5.1
 websocket-client==1.8.0
 pandas==2.2.2
 streamlit==1.46.0
+responses==0.25.2

--- a/tests/test_gh_api.py
+++ b/tests/test_gh_api.py
@@ -1,0 +1,47 @@
+import os
+import time
+from pathlib import Path
+
+import pytest
+import responses
+
+import sys
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import gh_api
+
+
+@pytest.mark.fast
+@responses.activate
+def test_pagination_and_rate_limit(monkeypatch):
+    os.environ['GH_BOT_TOKEN'] = 'x'
+    sleeps = []
+    monkeypatch.setattr(time, 'sleep', lambda s: sleeps.append(s))
+
+    responses.add(
+        responses.GET,
+        'https://api.github.com/repos/o/r/branches',
+        json=[{'name': 'a'}, {'name': 'b'}],
+        headers={
+            'Link': '<https://api.github.com/repos/o/r/branches?page=2>; rel="next"',
+            'X-RateLimit-Remaining': '15',
+        },
+        status=200,
+    )
+    responses.add(
+        responses.GET,
+        'https://api.github.com/repos/o/r/branches?page=2',
+        json=[{'name': 'c'}],
+        headers={'X-RateLimit-Remaining': '0', 'X-RateLimit-Reset': str(int(time.time()) + 1)},
+        status=200,
+    )
+
+    branches = gh_api.list_branches('o', 'r')
+    assert [b['name'] for b in branches] == ['a', 'b', 'c']
+    assert sleeps and sleeps[0] >= 1
+
+
+def test_missing_token(monkeypatch):
+    monkeypatch.delenv('GH_BOT_TOKEN', raising=False)
+    with pytest.raises(RuntimeError):
+        gh_api.api_request('GET', '/repos/foo/bar')


### PR DESCRIPTION
## Summary
- add `gh_api.py` with helpers for calling the GitHub REST API
- create `branch_pruner` agent using the API
- add MAE watcher script to check repo sync
- add reusable `set-token.yml` and reference it in CI workflows
- document GitHub token setup
- add tests for API helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859774b60348322ac719dcdf7ee73b9