### PR TITLE
Enable autonomous playground workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,12 @@ jobs:
           python-version: '3.x'
       - name: Install
         run: pip install -e .[dev]
+      - name: Guard generated.eidos size
+        run: |
+          sz=$(stat --printf="%s" generated.eidos)
+          if [ $sz -gt 204800 ]; then
+            echo "generated.eidos too big ($sz bytes)"; exit 1
+          fi
       - name: Run tests
         env:
           GH_BOT_TOKEN: ${{ secrets.GH_BOT_TOKEN || '' }}

--- a/.github/workflows/daily-playground.yml
+++ b/.github/workflows/daily-playground.yml
@@ -1,0 +1,31 @@
+name: Daily Playground
+on:
+  schedule:
+    - cron:  '17 3 * * *'  # 03:17 UTC daily
+jobs:
+  run-eidos:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with: {ref: main}
+      - uses: actions/setup-python@v5
+        with: {python-version: '3.x'}
+      - name: Install repo
+        run: pip install -e .[dev]
+      - name: Run emergent intelligence
+        env:
+          EIDOS_AUTOPUSH: 1
+        run: |
+          python emergent_intelligence.py
+      - name: Skip push if no diffs or too frequent
+        run: |
+          if git diff --quiet; then
+            echo "No changes."; exit 0; fi
+          last=$(git log -1 --format=%ct)
+          now=$(date +%s)
+          if [ $((now-last)) -lt 43200 ]; then
+            echo "Commit <12h old; skipping."; exit 0; fi
+      - name: Push
+        run: git push origin HEAD:main

--- a/.github/workflows/weekly-tuner.yml
+++ b/.github/workflows/weekly-tuner.yml
@@ -1,0 +1,25 @@
+name: Weekly Tuner
+on:
+  schedule:
+    - cron: '31 4 * * 0'
+jobs:
+  tune:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with: {ref: main}
+      - uses: actions/setup-python@v5
+        with: {python-version: '3.x'}
+      - name: Install repo
+        run: pip install -e .[dev]
+      - name: Run tuner
+        run: python agents/tuner.py
+      - name: Commit tuned params
+        run: |
+          if git diff --quiet; then
+            echo "No tuning changes"; exit 0; fi
+          git add tuning.json memory.json
+          git commit -m "chore: weekly tuner update"
+          git push origin HEAD:main

--- a/.github/workflows/weekly-visionary.yml
+++ b/.github/workflows/weekly-visionary.yml
@@ -1,0 +1,21 @@
+name: Weekly Visionary
+on:
+  schedule:
+    - cron: '23 4 * * 1'
+jobs:
+  vision:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with: {ref: main}
+      - uses: actions/setup-python@v5
+        with: {python-version: '3.x'}
+      - name: Install repo
+        run: pip install -e .[dev]
+      - name: Run visionary
+        env:
+          GH_BOT_TOKEN: ${{ secrets.GH_BOT_TOKEN }}
+        run: python agents/visionary.py


### PR DESCRIPTION
## Summary
- log metrics from daily run
- commit new scripts directly to main
- guard `generated.eidos` size in CI
- add daily, weekly tuner, and weekly visionary workflows

## Testing
- `pip install -e .[dev]`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686ec36ab6548322a60be4a85c156ef1