### PR TITLE
feat: observer & shadow agents with helper scaffolding

### DIFF
--- a/.github/workflows/observe-loop.yml
+++ b/.github/workflows/observe-loop.yml
@@ -1,0 +1,25 @@
+name: Observer Loop
+on:
+  schedule:
+    - cron: '*/15 * * * *'
+jobs:
+  observe:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - run: pip install -e .[dev,explore,observer,local]
+      - name: Run Observer
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          USE_LOCAL_SHADOW: ${{ secrets.USE_LOCAL_SHADOW }}
+        run: python observer.py
+      - name: Commit Observer Changes
+        run: |
+          if ! git diff --quiet; then
+            git add -A
+            git commit -m "chore: observer auto-update"
+            git push
+          fi

--- a/agents/helpers/__init__.py
+++ b/agents/helpers/__init__.py
@@ -1,0 +1,1 @@
+# helper modules

--- a/forge/__main__.py
+++ b/forge/__main__.py
@@ -1,0 +1,4 @@
+from .new import main
+
+if __name__ == "__main__":
+    main()

--- a/forge/helper/helper_diff/cookiecutter.json
+++ b/forge/helper/helper_diff/cookiecutter.json
@@ -1,0 +1,3 @@
+{
+  "helper_name": "diff_helper"
+}

--- a/forge/helper/helper_diff/{{cookiecutter.helper_name}}.py
+++ b/forge/helper/helper_diff/{{cookiecutter.helper_name}}.py
@@ -1,0 +1,5 @@
+"""Diff helper."""
+
+
+def compute():
+    print("diff helper")

--- a/forge/helper/helper_metrics/cookiecutter.json
+++ b/forge/helper/helper_metrics/cookiecutter.json
@@ -1,0 +1,3 @@
+{
+  "helper_name": "metrics_helper"
+}

--- a/forge/helper/helper_metrics/{{cookiecutter.helper_name}}.py
+++ b/forge/helper/helper_metrics/{{cookiecutter.helper_name}}.py
@@ -1,0 +1,5 @@
+"""Observer helper."""
+
+
+def run():
+    print("helper running")

--- a/forge/new.py
+++ b/forge/new.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from cookiecutter.main import cookiecutter
+
+HERE = Path(__file__).resolve().parent
+TEMPLATES = HERE / "helper"
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command")
+    helper_p = sub.add_parser("helper")
+    helper_p.add_argument("--name", required=True)
+    helper_p.add_argument("--template", default="metrics")
+    args = parser.parse_args(argv)
+
+    if args.command == "helper":
+        template = TEMPLATES / f"helper_{args.template}"
+        dest_dir = Path("agents/helpers")
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        cookiecutter(str(template), no_input=True, output_dir=str(dest_dir),
+                    extra_context={"helper_name": args.name})
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/observer.py
+++ b/observer.py
@@ -1,0 +1,94 @@
+"""Observe execution results and plan next steps."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from datetime import datetime
+from typing import Dict
+
+import yaml
+import subprocess
+import shadow
+
+TODO_DIR = Path("todo")
+EXPERIENCES_DIR = Path("experiences")
+METRICS_FILE = Path("metrics/actions.jsonl")
+OBSERVER_LOG = Path("metrics/observer.jsonl")
+
+
+def _latest_card() -> Path | None:
+    TODO_DIR.mkdir(exist_ok=True)
+    cards = sorted(TODO_DIR.glob("*.yaml"))
+    return cards[-1] if cards else None
+
+
+def _latest_metrics() -> str:
+    if METRICS_FILE.exists():
+        with METRICS_FILE.open() as f:
+            lines = f.readlines()
+        return lines[-1].strip() if lines else ""
+    return ""
+
+
+def _latest_artefacts() -> list[Path]:
+    if not EXPERIENCES_DIR.exists():
+        return []
+    dirs = sorted(EXPERIENCES_DIR.glob("*"))
+    if not dirs:
+        return []
+    latest = dirs[-1]
+    return list(latest.glob("*"))
+
+
+def observe_and_plan(dry_run: bool = False) -> Dict:
+    card_path = _latest_card()
+    card_text = card_path.read_text() if card_path else ""
+    metrics = _latest_metrics()
+    artefacts = _latest_artefacts()
+    artefact_names = [p.name for p in artefacts]
+
+    prompt = (
+        "Latest card:\n" + card_text + "\n" +
+        "Metrics: " + metrics + "\n" +
+        "Artefacts: " + ", ".join(artefact_names)
+    )
+    messages = [
+        {"role": "system", "content": "You are the Observer agent."},
+        {"role": "user", "content": prompt},
+    ]
+    plan = shadow.chat_with_shadow(messages)
+
+    if not dry_run:
+        if plan.get("type") == "patch" and plan.get("diff"):
+            diff = plan["diff"]
+            subprocess.run(["git", "apply", "--whitespace=fix", "-"],
+                           input=diff.encode(), check=True)
+        elif plan.get("type") == "card" and plan.get("card"):
+            name = datetime.utcnow().strftime("%Y%m%d_%H%M%S_card.yaml")
+            TODO_DIR.mkdir(exist_ok=True)
+            (TODO_DIR / name).write_text(plan["card"])
+    log = {
+        "ts": datetime.utcnow().isoformat(),
+        "card": card_path.name if card_path else None,
+        "metric": metrics,
+        "plan": plan,
+    }
+    OBSERVER_LOG.parent.mkdir(parents=True, exist_ok=True)
+    with OBSERVER_LOG.open("a") as f:
+        f.write(json.dumps(log) + "\n")
+    return plan
+
+
+def main() -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    observe_and_plan(dry_run=args.dry_run)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,13 @@ explore = [
     "cookiecutter",
     "jq",
 ]
+observer = [
+    "openai",
+    "transformers",
+    "pyyaml",
+    "gitpython",
+    "jq",
+]
 
 [project.scripts]
 eidos-agent = "agents.__init__:get"

--- a/shadow.py
+++ b/shadow.py
@@ -1,0 +1,46 @@
+import os
+import json
+from typing import List, Dict
+
+
+def _local_reply(prompt: str) -> str:
+    """Generate a dummy JSON reply using a local transformers model if available."""
+    try:
+        from transformers import pipeline
+
+        model_name = os.getenv("LOCAL_SHADOW_MODEL", "sshleifer/tiny-gpt2")
+        generator = pipeline("text-generation", model=model_name)
+        out = generator(prompt, max_new_tokens=64, do_sample=False)[0]["generated_text"]
+        return out
+    except Exception:
+        # Fallback to a static response
+        return '{"type": "card", "card": "kind: note\nname: local"}'
+
+
+def chat_with_shadow(messages: List[Dict]) -> Dict:
+    """Send ``messages`` to the shadow model and return a parsed JSON dict."""
+    use_local = os.getenv("USE_LOCAL_SHADOW")
+    if use_local:
+        prompt = messages[-1]["content"] if messages else ""
+        text = _local_reply(prompt)
+    else:
+        import openai
+
+        resp = openai.ChatCompletion.create(
+            model="gpt-4o-mini",
+            messages=messages,
+            temperature=0,
+        )
+        text = resp.choices[0].message.content
+    try:
+        data = json.loads(text)
+    except Exception:
+        data = {"type": "card", "card": "kind: note\nname: parse_error"}
+    return data
+
+
+if __name__ == "__main__":
+    import sys
+
+    result = chat_with_shadow([{"role": "user", "content": "".join(sys.argv[1:])}])
+    print(json.dumps(result, indent=2))

--- a/tests/test_observer.py
+++ b/tests/test_observer.py
@@ -1,0 +1,26 @@
+import json
+from pathlib import Path
+import observer
+
+
+def test_observe_and_plan(tmp_path, monkeypatch):
+    todo = tmp_path / 'todo'
+    exp_dir = tmp_path / 'experiences/2024-01-01'
+    metrics_dir = tmp_path / 'metrics'
+    todo.mkdir()
+    exp_dir.mkdir(parents=True)
+    metrics_dir.mkdir()
+
+    card = todo / 'card.yaml'
+    card.write_text('kind: note\nname: test')
+    (metrics_dir / 'actions.jsonl').write_text('{}\n')
+
+    monkeypatch.setattr(observer, 'TODO_DIR', todo)
+    monkeypatch.setattr(observer, 'EXPERIENCES_DIR', tmp_path / 'experiences')
+    monkeypatch.setattr(observer, 'METRICS_FILE', metrics_dir / 'actions.jsonl')
+    monkeypatch.setattr(observer, 'OBSERVER_LOG', metrics_dir / 'observer.jsonl')
+    monkeypatch.setattr(observer, 'shadow', type('s', (), {'chat_with_shadow': lambda m: {'type': 'card', 'card': 'kind: note\nname: new'}}))
+
+    result = observer.observe_and_plan()
+    assert (metrics_dir / 'observer.jsonl').exists()
+    assert result['type'] == 'card'

--- a/tests/test_shadow.py
+++ b/tests/test_shadow.py
@@ -1,0 +1,9 @@
+import os
+import shadow
+
+
+def test_chat_with_shadow(monkeypatch):
+    monkeypatch.setenv("USE_LOCAL_SHADOW", "1")
+    result = shadow.chat_with_shadow([{"role": "user", "content": "hello"}])
+    assert isinstance(result, dict)
+    assert "type" in result


### PR DESCRIPTION
## Summary
- implement `observer.py` and `shadow.py` for Observer and Shadow agents
- add helper scaffold CLI with cookiecutter templates
- schedule observer loop workflow
- extend optional dependencies for observer tools
- provide unit tests for new modules

## Testing
- `pip install -e .[dev,explore]`
- `pytest -q`
- `yamllint .github/workflows todo`
- `USE_LOCAL_SHADOW=1 python observer.py --dry-run`

------
https://chatgpt.com/codex/tasks/task_e_686ed48d3d588322be54a3a326239b49