### PR TITLE
Add quantum engine scaffolding

### DIFF
--- a/quantum_engine/__init__.py
+++ b/quantum_engine/__init__.py
@@ -1,0 +1,5 @@
+"""Quantum engine subpackage."""
+
+from .constants import CONSTS
+from .engine import run, create_state
+from .solver import EngineState

--- a/quantum_engine/constants.py
+++ b/quantum_engine/constants.py
@@ -1,0 +1,14 @@
+"""Global constants for the quantum engine."""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Constants:
+    lP: float = 1.0
+    alpha0: float = 1e-2
+    beta0: float = 1e-2
+    xi: float = 0.0
+
+
+CONSTS = Constants()

--- a/quantum_engine/engine.py
+++ b/quantum_engine/engine.py
@@ -1,0 +1,27 @@
+"""Facade for optimisation loop."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import optax
+
+from .solver import EngineState, train_step
+from .matter import DiracKahlerField
+
+
+def create_state(d: int = 2) -> EngineState:
+    g = jnp.eye(d)
+    field = DiracKahlerField(jnp.zeros(()), jnp.zeros((d,)), jnp.zeros((d, d)))
+    return EngineState(g=g, field=field)
+
+
+def run(num_steps: int = 1_000):
+    state = create_state()
+    opt = optax.adam(1e-3)
+    opt_state = opt.init(state)
+    for _ in range(num_steps):
+        state, opt_state, loss = train_step(state, opt, opt_state)
+        # Simple CLI output
+        if state.step % 100 == 0:
+            print(f"step {state.step} loss {loss}")
+    return state

--- a/quantum_engine/entropy.py
+++ b/quantum_engine/entropy.py
@@ -1,0 +1,28 @@
+"""Positive-definite enforcement and entropy helpers."""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+
+from .geometry import logm, tr_g
+
+
+def flatten(tensor: jnp.ndarray, order: str = "C") -> jnp.ndarray:
+    """Flatten a tensor for spectrum computations."""
+    return jnp.reshape(tensor, (-1, tensor.shape[-1])) if tensor.ndim > 1 else jnp.ravel(tensor)
+
+
+def enforce_pd(matrix: jnp.ndarray, softplus: bool = True) -> jnp.ndarray:
+    """Return a positive-definite version of ``matrix``."""
+    vals, vecs = jnp.linalg.eigh(matrix)
+    if softplus:
+        vals = jax.nn.softplus(vals)
+    else:
+        vals = jnp.clip(vals, 1e-6)
+    return (vecs * vals) @ jnp.conj(vecs.T)
+
+
+def entropy_density(G: jnp.ndarray, g: jnp.ndarray) -> jnp.ndarray:
+    """Diagnostic entropy density."""
+    return -tr_g(logm(G @ jnp.linalg.inv(g)), g)

--- a/quantum_engine/geometry.py
+++ b/quantum_engine/geometry.py
@@ -1,0 +1,34 @@
+"""Geometry utilities for entropic action computations."""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+
+from .constants import CONSTS
+
+
+def logm(matrix: jnp.ndarray) -> jnp.ndarray:
+    """Hermitian-safe matrix logarithm."""
+    vals, vecs = jnp.linalg.eigh(matrix)
+    vals = jnp.clip(vals, 1e-30)
+    log_vals = jnp.log(vals)
+    return (vecs * log_vals) @ jnp.conj(vecs.T)
+
+
+def tr_g(A: jnp.ndarray, g: jnp.ndarray) -> jnp.ndarray:
+    """Trace with respect to metric ``g``."""
+    return jnp.trace(g @ A)
+
+
+def entropic_action(g: jnp.ndarray, G: jnp.ndarray) -> jnp.ndarray:
+    """Return the entropic action for metrics ``g`` and ``G``."""
+    d = g.shape[0]
+    L = -tr_g(logm(jnp.linalg.inv(G)), g)
+    vol = jnp.sqrt(jnp.abs(jnp.linalg.det(-g)))
+    return (1.0 / CONSTS.lP**d) * vol * L
+
+
+def entropic_gradients(g: jnp.ndarray, G: jnp.ndarray):
+    """Gradients of entropic action with respect to ``g`` and ``G``."""
+    return jax.grad(entropic_action, argnums=(0, 1))(g, G)

--- a/quantum_engine/induced_metric.py
+++ b/quantum_engine/induced_metric.py
@@ -1,0 +1,24 @@
+"""Assemble the induced metric G."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+
+from .constants import CONSTS
+from .matter import DiracKahlerField
+
+
+def compute_ricci(g: jnp.ndarray) -> jnp.ndarray:
+    """Placeholder Ricci tensor computation."""
+    # TODO: implement finite element Ricci tensor
+    return jnp.zeros_like(g)
+
+
+def assemble_G(g: jnp.ndarray, field: DiracKahlerField) -> jnp.ndarray:
+    """Return the induced metric G as in Eq (2)."""
+    d = g.shape[0]
+    alpha = CONSTS.alpha0 * CONSTS.lP**d
+    beta = CONSTS.beta0 * CONSTS.lP**2
+    M = field.kinetic_block(g)
+    R = compute_ricci(g)
+    return g + alpha * M - beta * R

--- a/quantum_engine/matter.py
+++ b/quantum_engine/matter.py
@@ -1,0 +1,29 @@
+"""Dirac--K\xE4hler matter field stack."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import jax.numpy as jnp
+
+
+@dataclass
+class DiracKahlerField:
+    scalar: jnp.ndarray
+    one_form: jnp.ndarray
+    two_form: jnp.ndarray
+
+    def d(self) -> "DiracKahlerField":
+        """Exterior derivative stencil (placeholder)."""
+        # TODO: implement finite difference operators
+        return self  # placeholder
+
+    def delta(self) -> "DiracKahlerField":
+        """Coderivative stencil (placeholder)."""
+        # TODO: implement coderivative
+        return self  # placeholder
+
+    def kinetic_block(self, g: jnp.ndarray) -> jnp.ndarray:
+        """Return matter current pieces for induced metric."""
+        # TODO: compute gradients and assemble tensor
+        return jnp.zeros_like(g)

--- a/quantum_engine/solver.py
+++ b/quantum_engine/solver.py
@@ -1,0 +1,39 @@
+"""Training loop utilities for the quantum engine."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import jax
+import jax.numpy as jnp
+import optax
+import equinox as eqx
+
+from .geometry import entropic_action
+from .induced_metric import assemble_G
+from .entropy import enforce_pd
+from .matter import DiracKahlerField
+
+
+@dataclass
+class EngineState:
+    g: jnp.ndarray
+    field: DiracKahlerField
+    step: int = 0
+
+    @property
+    def G(self) -> jnp.ndarray:
+        return assemble_G(self.g, self.field)
+
+
+def physics_loss(state: EngineState) -> jnp.ndarray:
+    G = enforce_pd(state.G)
+    return jnp.mean(entropic_action(state.g, G))
+
+
+def train_step(state: EngineState, opt: optax.GradientTransformation, opt_state):
+    loss, grads = jax.value_and_grad(physics_loss)(state)
+    updates, opt_state = opt.update(grads, opt_state)
+    state = eqx.apply_updates(state, updates)
+    state.step += 1
+    return state, opt_state, loss


### PR DESCRIPTION
## Summary
- implement quantum engine scaffolding with JAX
- add geometry utilities for entropic action
- add entropy and PD helpers
- create placeholders for Dirac–Kähler matter fields
- add induced metric and solver stubs
- expose simple training loop

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870124c9e088322a9fef063635fcde9