### PR TITLE
Fix git push command for observer

### DIFF
--- a/.github/workflows/observe-loop.yml
+++ b/.github/workflows/observe-loop.yml
@@ -17,9 +17,19 @@ jobs:
           USE_LOCAL_SHADOW: ${{ secrets.USE_LOCAL_SHADOW }}
         run: python observer.py
       - name: Commit Observer Changes
+        env:
+          PUSH_TOKEN: ${{ secrets.PUSH_TOKEN }}
         run: |
+          git config user.name "eidos-bot"
+          git config user.email "eidos-bot@users.noreply.github.com"
           if ! git diff --quiet; then
             git add -A
             git commit -m "chore: observer auto-update"
-            git push
+            if [ -n "$PUSH_TOKEN" ]; then
+              repo_base="https://x-access-token:${PUSH_TOKEN}@github.com/"
+              repo="${repo_base}${GITHUB_REPOSITORY}.git"
+              git push "$repo" HEAD:main
+            else
+              git push
+            fi
           fi


### PR DESCRIPTION
## Summary
- adjust commit step for observer loop workflow
- define repo variable to keep each line short

## Testing
- `yamllint .github/workflows todo`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687016a06130832280f4eef9300fca95