### PR TITLE
Update OpenAI client usage

### DIFF
--- a/agents/planner.py
+++ b/agents/planner.py
@@ -25,7 +25,13 @@ def plan(prompt: str = "Plan next action") -> Path:
             cost_estimate = len(prompt)
             if not within_budget("openai", cost_estimate):
                 raise RuntimeError("API budget exceeded")
-            resp = openai.ChatCompletion.create(
+
+            client = getattr(plan, "_client", None)
+            if client is None:
+                client = openai.OpenAI()
+                setattr(plan, "_client", client)
+
+            resp = client.chat.completions.create(
                 model="gpt-3.5-turbo",
                 messages=[{"role": "user", "content": prompt}],
                 max_tokens=200,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,12 +23,12 @@ dev = [
 explore = [
     "chromadb",
     "pyyaml",
-    "openai",
+    "openai>=1.0",
     "cookiecutter",
     "jq",
 ]
 observer = [
-    "openai",
+    "openai>=1.0",
     "transformers",
     "pyyaml",
     "gitpython",

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ numpy
 requests
 optuna
 streamlit
+openai>=1.0
 
 # development extras
 pytest-mock

--- a/shadow.py
+++ b/shadow.py
@@ -26,7 +26,12 @@ def chat_with_shadow(messages: List[Dict]) -> Dict:
     else:
         import openai
 
-        resp = openai.ChatCompletion.create(
+        client = getattr(chat_with_shadow, "_client", None)
+        if client is None:
+            client = openai.OpenAI()
+            setattr(chat_with_shadow, "_client", client)
+
+        resp = client.chat.completions.create(
             model="gpt-4o-mini",
             messages=messages,
             temperature=0,


### PR DESCRIPTION
## Summary
- use `openai.OpenAI` client in the shadow helper
- update planner to use the same pattern
- depend on `openai>=1.0`

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687667949bb083229d514bbc4b8727db