### PR TITLE
Fix calc_surprise input handling

### DIFF
--- a/.github/workflows/every-15min.yml
+++ b/.github/workflows/every-15min.yml
@@ -17,8 +17,8 @@ jobs:
         run: |
           paused=$(gh api -H "Accept: application/vnd.github+json" \
             "/repos/${{ github.repository }}/issues?state=open" | \
-            jq -r '.[] |\
-              select(.title | test("PAUSE EIDOS"; "i")) |\
+            jq -r '.[] |
+              select(.title | test("PAUSE EIDOS"; "i")) |
               .number' | head -1)
           [ -z "$paused" ] || { echo "Paused by issue #$paused"; exit 0; }
       - run: python executor.py

--- a/curiosity.py
+++ b/curiosity.py
@@ -11,11 +11,10 @@ STORE.parent.mkdir(exist_ok=True)
 
 
 def _as_float_array(vec: Union[NumberArray, bytes, str]) -> np.ndarray:
-    """Return ``vec`` as ``np.float32`` array, raising ``TypeError`` for bytes."""
+    """Return ``vec`` as ``np.float32`` array, raising ``ValueError`` for bytes."""
     if isinstance(vec, (bytes, str)):
-        raise TypeError(
-            "calc_surprise expected numeric sequence, received bytes/str. "
-            "Upstream caller must decode embeddings to float list first."
+        raise ValueError(
+            "Input vector must be a numeric array, not bytes or string."
         )
     return np.asarray(vec, dtype=np.float32)
 

--- a/tests/test_curiosity.py
+++ b/tests/test_curiosity.py
@@ -13,7 +13,7 @@ def test_calc_surprise_updates(tmp_path, monkeypatch):
 
 
 def test_bytes_error():
-    with pytest.raises(TypeError):
+    with pytest.raises(ValueError):
         curiosity.calc_surprise(b"\x00\x01")
 
 


### PR DESCRIPTION
## Summary
- validate input in `calc_surprise`
- adjust curiosity tests for new ValueError
- fix quoting in pause-check workflow step

## Testing
- `pip install -e .[dev]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876bf02ca94832291913ac8891dbcd9